### PR TITLE
feat(user-activity): soft-disable пользователей + глобальные защёлки

### DIFF
--- a/internal/app/dispatcher.go
+++ b/internal/app/dispatcher.go
@@ -38,6 +38,13 @@ func HandleMessage(bot *tgbotapi.BotAPI, database *sql.DB, msg *tgbotapi.Message
 			bot.Send(msg)
 			return
 		}
+		// 🔒 Пользователь зарегистрирован, но неактивен — доступ закрыт, клавиатуру убираем
+		if !user.IsActive {
+			rm := tgbotapi.NewMessage(chatID, "🚫 Доступ к боту временно закрыт. Обратитесь к администратору.")
+			rm.ReplyMarkup = tgbotapi.NewRemoveKeyboard(true)
+			bot.Send(rm)
+			return
+		}
 
 		// Пользователь уже зарегистрирован
 		db.SetUserFSMRole(chatID, string(*user.Role))
@@ -63,6 +70,14 @@ func HandleMessage(bot *tgbotapi.BotAPI, database *sql.DB, msg *tgbotapi.Message
 		}
 
 		bot.Send(tgbotapi.NewMessage(chatID, "⚠️ Вы не зарегистрированы. Пожалуйста, нажмите /start для начала."))
+		return
+	}
+	// 🔒 Глобальная защёлка: неактивным — ни одну команду
+	if user != nil && !user.IsActive {
+		rm := tgbotapi.NewMessage(chatID, "🚫 Доступ к боту временно закрыт. Обратитесь к администратору.")
+		// на случай, если у пользователя осталась старая клавиатура — уберём
+		rm.ReplyMarkup = tgbotapi.NewRemoveKeyboard(true)
+		bot.Send(rm)
 		return
 	}
 	if handlers.GetAddScoreState(chatID) != nil {
@@ -127,7 +142,7 @@ func HandleMessage(bot *tgbotapi.BotAPI, database *sql.DB, msg *tgbotapi.Message
 		}
 	case "/export", "📥 Экспорт отчёта":
 		if *user.Role == "admin" || *user.Role == "administration" {
-			go handlers.StartExportFSM(bot, msg)
+			go handlers.StartExportFSM(bot, database, msg)
 		}
 	case "👥 Пользователи":
 		if *user.Role == "admin" {
@@ -152,6 +167,21 @@ func HandleMessage(bot *tgbotapi.BotAPI, database *sql.DB, msg *tgbotapi.Message
 func HandleCallback(bot *tgbotapi.BotAPI, database *sql.DB, cb *tgbotapi.CallbackQuery) {
 	data := cb.Data
 	chatID := cb.Message.Chat.ID
+
+	// 🔒 Глобальная защёлка для inline-кнопок: неактивным всё режем
+	// берём пользователя по Telegram ID отправителя колбэка.
+	if cb.From != nil {
+		if u, err := db.GetUserByTelegramID(database, cb.From.ID); err == nil && u != nil && !u.IsActive {
+			// Всегда отвечаем на колбэк, чтобы Telegram "разморозил" UI
+			bot.Request(tgbotapi.NewCallback(cb.ID, "Доступ закрыт"))
+			// И даём явное сообщение в чат (на случай, если кнопка была из старого меню)
+			msg := tgbotapi.NewMessage(chatID, "🚫 Доступ к боту временно закрыт. Обратитесь к администратору.")
+			// Уберём возможную «залипшую» клавиатуру
+			msg.ReplyMarkup = tgbotapi.NewRemoveKeyboard(true)
+			bot.Send(msg)
+			return
+		}
+	}
 
 	log.Printf("CB from %d: %s (msgID=%d)\n", cb.From.ID, cb.Data, cb.Message.MessageID)
 
@@ -288,6 +318,7 @@ func HandleCallback(bot *tgbotapi.BotAPI, database *sql.DB, cb *tgbotapi.Callbac
 	}
 	if strings.HasPrefix(data, "exp_users_") {
 		user, _ := db.GetUserByTelegramID(database, chatID)
+
 		isAdmin := *user.Role == models.Admin || *user.Role == models.Administration
 		switch data {
 		case "exp_users_open":

--- a/internal/bot/handlers/approve_fsm.go
+++ b/internal/bot/handlers/approve_fsm.go
@@ -8,12 +8,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Spok95/telegram-school-bot/internal/bot/shared/fsmutil"
 	"github.com/Spok95/telegram-school-bot/internal/db"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
 // ShowPendingScores показывает администратору все заявки с status = 'pending'
 func ShowPendingScores(bot *tgbotapi.BotAPI, database *sql.DB, adminID int64) {
+	// запрет неактивным
+	admin, err := db.GetUserByID(database, adminID)
+	if err == nil {
+		if !fsmutil.MustBeActiveForOps(&admin) {
+			bot.Send(tgbotapi.NewMessage(adminID, "🚫 Доступ временно закрыт. Обратитесь к администратору."))
+			return
+		}
+	}
 	scores, err := db.GetPendingScores(database)
 	if err != nil {
 		log.Println("ошибка при получении заявок на баллы:", err)

--- a/internal/bot/handlers/export_fsm.go
+++ b/internal/bot/handlers/export_fsm.go
@@ -40,8 +40,13 @@ type ExportFSMState struct {
 var exportStates = make(map[int64]*ExportFSMState)
 
 // стартовое меню (новое сообщение)
-func StartExportFSM(bot *tgbotapi.BotAPI, msg *tgbotapi.Message) {
+func StartExportFSM(bot *tgbotapi.BotAPI, database *sql.DB, msg *tgbotapi.Message) {
 	chatID := msg.Chat.ID
+	u, _ := db.GetUserByTelegramID(database, chatID)
+	if u == nil || !fsmutil.MustBeActiveForOps(u) {
+		bot.Send(tgbotapi.NewMessage(chatID, "🚫 Доступ временно закрыт. Обратитесь к администратору."))
+		return
+	}
 	exportStates[chatID] = &ExportFSMState{Step: ExportStepReportType}
 
 	rows := [][]tgbotapi.InlineKeyboardButton{

--- a/internal/bot/handlers/migrations/0001_init.sql
+++ b/internal/bot/handlers/migrations/0001_init.sql
@@ -10,8 +10,12 @@ CREATE TABLE users (
                        class_letter TEXT,
                        child_id BIGINT,
                        confirmed BOOLEAN NOT NULL DEFAULT FALSE,
-                       is_active BOOLEAN NOT NULL DEFAULT TRUE
+                       is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                       deactivated_at  TIMESTAMPTZ
 );
+
+CREATE INDEX idx_users_role_active ON users(role, is_active);
+CREATE INDEX idx_users_deactivated_at ON users(deactivated_at);
 
 CREATE TABLE classes (
                          id BIGSERIAL PRIMARY KEY,

--- a/internal/bot/handlers/myscore.go
+++ b/internal/bot/handlers/myscore.go
@@ -13,8 +13,11 @@ import (
 func HandleMyScore(bot *tgbotapi.BotAPI, database *sql.DB, msg *tgbotapi.Message) {
 	chatID := msg.Chat.ID
 	user, err := db.GetUserByTelegramID(database, chatID)
-	if err != nil || user == nil {
-		bot.Send(tgbotapi.NewMessage(chatID, "❌ Пользователь не найден."))
+	if err != nil {
+		log.Println("Пользователь найден:", err)
+	}
+	if user == nil || !user.IsActive {
+		bot.Send(tgbotapi.NewMessage(chatID, "🚫 Доступ к боту временно закрыт. Обратитесь к администратору."))
 		return
 	}
 

--- a/internal/bot/shared/fsmutil/fsmutil.go
+++ b/internal/bot/shared/fsmutil/fsmutil.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Spok95/telegram-school-bot/internal/models"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
@@ -61,4 +62,16 @@ func BackCancelRow(backData, cancelData string) []tgbotapi.InlineKeyboardButton 
 func IsCancelText(s string) bool {
 	s = strings.TrimSpace(strings.ToLower(s))
 	return s == "отмена" || s == "/cancel" || s == "cancel"
+}
+
+// MustBeActiveForOps — доступ к операциям только для активных пользователей.
+func MustBeActiveForOps(u *models.User) bool {
+	switch *u.Role {
+	case models.Teacher, models.Administration, models.Admin:
+		return u.IsActive
+	case models.Parent, models.Student:
+		return u.IsActive
+	default:
+		return true
+	}
 }

--- a/internal/db/users_export.go
+++ b/internal/db/users_export.go
@@ -32,7 +32,7 @@ func ListAllUsers(database *sql.DB, includeInactive bool) ([]UserRow, error) {
 		q = `
 		SELECT u.name, COALESCE(u.role, '') AS role, u.class_number, u.class_letter
 		FROM users u
-		WHERE u.confirmed = TRUE
+		WHERE u.confirmed = TRUE AND u.is_active=TRUE
 		ORDER BY LOWER(u.name)`
 	} else {
 		q = `
@@ -62,7 +62,7 @@ func ListAllUsers(database *sql.DB, includeInactive bool) ([]UserRow, error) {
 func ListTeachers(database *sql.DB, includeInactive bool) ([]string, error) {
 	q := ""
 	if !includeInactive {
-		q = "SELECT u.name FROM users u WHERE u.role='teacher' AND u.confirmed=TRUE ORDER BY LOWER(u.name)"
+		q = "SELECT u.name FROM users u WHERE u.role='teacher' AND u.confirmed=TRUE AND u.is_active=TRUE ORDER BY LOWER(u.name)"
 	} else {
 		q = "SELECT u.name FROM users u WHERE u.role='teacher' ORDER BY LOWER(u.name)"
 	}
@@ -85,7 +85,7 @@ func ListTeachers(database *sql.DB, includeInactive bool) ([]string, error) {
 func ListAdministration(database *sql.DB, includeInactive bool) ([]string, error) {
 	q := ""
 	if !includeInactive {
-		q = "SELECT u.name FROM users u WHERE u.role='administration' AND u.confirmed=TRUE ORDER BY LOWER(u.name)"
+		q = "SELECT u.name FROM users u WHERE u.role='administration' AND u.confirmed=TRUE AND u.is_active=TRUE ORDER BY LOWER(u.name)"
 	} else {
 		q = "SELECT u.name FROM users u WHERE u.role='administration' ORDER BY LOWER(u.name)"
 	}
@@ -118,7 +118,7 @@ func ListStudents(database *sql.DB, includeInactive bool) ([]StudentRow, error) 
 
 	if !includeInactive {
 		q += `
-		WHERE u.role='student' AND u.confirmed=TRUE
+		WHERE u.role='student' AND u.confirmed=TRUE AND u.is_active=TRUE
 		GROUP BY u.id
 		ORDER BY COALESCE(u.class_number,0), u.class_letter, LOWER(u.name)
 	`
@@ -161,7 +161,7 @@ func ListParents(database *sql.DB, includeInactive bool) ([]ParentRow, error) {
 	`
 	if !includeInactive {
 		q += `
-		WHERE u.role='parent' AND u.confirmed=TRUE
+		WHERE u.role='parent' AND u.confirmed=TRUE AND u.is_active=TRUE
 		GROUP BY u.id
 		ORDER BY LOWER(u.name)
 	`

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 type Role string
 
 const (
@@ -11,17 +13,18 @@ const (
 )
 
 type User struct {
-	ID          int64   `db:"id"`
-	TelegramID  int64   `db:"telegram_id"`
-	Name        string  `db:"name"`
-	Role        *Role   `db:"role"`
-	ClassID     *int64  `db:"class_id"`
-	ClassName   *string `db:"class_name"`
-	ClassNumber *int64  `db:"class_number"`
-	ClassLetter *string `db:"class_letter"`
-	ChildID     *int64  `db:"child_id"`
-	Confirmed   bool    `db:"confirmed"`
-	IsActive    bool    `db:"is_active"`
+	ID            int64      `db:"id"`
+	TelegramID    int64      `db:"telegram_id"`
+	Name          string     `db:"name"`
+	Role          *Role      `db:"role"`
+	ClassID       *int64     `db:"class_id"`
+	ClassName     *string    `db:"class_name"`
+	ClassNumber   *int64     `db:"class_number"`
+	ClassLetter   *string    `db:"class_letter"`
+	ChildID       *int64     `db:"child_id"`
+	Confirmed     bool       `db:"confirmed"`
+	IsActive      bool       `db:"is_active"`
+	DeactivatedAt *time.Time `db:"deactivated_at"`
 }
 
 type Class struct {


### PR DESCRIPTION
- блокируем неактивных в dispatcher (message/callback)
- исключаем неактивных из выборов и повторно проверяем при подтверждении
- защита для аукциона (нет активных/недостаточно баллов → без заявок)
- экспорт «Пользователи»: переключатель активных/неактивных
- fix(db): GetStudentsByClass — корректный Scan(id,name)
- admin: ACK колбэков активации/деактивации и перерасчёт родителей